### PR TITLE
Account for large items inside containers & add more methods to NbtUtility

### DIFF
--- a/patches/server/0031-Make-the-maximum-tag-size-a-constant-add-a-method-fo.patch
+++ b/patches/server/0031-Make-the-maximum-tag-size-a-constant-add-a-method-fo.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Business Goose <arclicious@vivaldi.net>
+Date: Sun, 1 May 2022 01:19:36 +0100
+Subject: [PATCH] Make the maximum tag size a constant & add a method for
+ getting tag size
+
+
+diff --git a/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java b/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java
+index 058203440fd071ce5edbe18391ea60f0a5fbee3a..dc09fe007247e832aacc323ddeb3541cfb447069 100644
+--- a/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java
++++ b/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java
+@@ -7,11 +7,17 @@ import java.nio.charset.StandardCharsets;
+ 
+ public class NbtUtility
+ {
++    public static final long MAXIMUM_SIZE = (256 * 1024);
++
++    public static long getTagSize(@Nullable CompoundTag tag) {
++        if(tag == null) return 0;
++        return tag.toString().getBytes(StandardCharsets.UTF_8).length;
++    }
+ 
+     public static boolean isTooLarge(@Nullable CompoundTag tag)
+     {
+         if (tag == null) return false;
+-        return tag.toString().getBytes(StandardCharsets.UTF_8).length > (256 * 1024);
++        return getTagSize(tag) > MAXIMUM_SIZE;
+     }
+ 
+     public static class Item

--- a/patches/server/0032-Account-for-items-inside-containers.patch
+++ b/patches/server/0032-Account-for-items-inside-containers.patch
@@ -1,0 +1,267 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Business Goose <arclicious@vivaldi.net>
+Date: Sun, 1 May 2022 01:20:13 +0100
+Subject: [PATCH] Account for items inside containers
+
+
+diff --git a/src/main/java/net/minecraft/world/ContainerHelper.java b/src/main/java/net/minecraft/world/ContainerHelper.java
+index 4092c7a8c2b0d9d26e6f4d97386735236300d132..ad3af6d90b68bc55c29243da8814516575299bf0 100644
+--- a/src/main/java/net/minecraft/world/ContainerHelper.java
++++ b/src/main/java/net/minecraft/world/ContainerHelper.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import java.util.List;
+ import java.util.function.Predicate;
+ import net.minecraft.core.NonNullList;
+@@ -22,10 +23,14 @@ public class ContainerHelper {
+ 
+     public static CompoundTag saveAllItems(CompoundTag nbt, NonNullList<ItemStack> stacks, boolean setIfEmpty) {
+         ListTag listTag = new ListTag();
++        // Scissors - Account for items inside containers
++        long total = 0;
+ 
+         for(int i = 0; i < stacks.size(); ++i) {
+             ItemStack itemStack = stacks.get(i);
++
+             if (!itemStack.isEmpty()) {
++                total += NbtUtility.getTagSize(itemStack.getTag());
+                 CompoundTag compoundTag = new CompoundTag();
+                 compoundTag.putByte("Slot", (byte)i);
+                 itemStack.save(compoundTag);
+@@ -33,7 +38,7 @@ public class ContainerHelper {
+             }
+         }
+ 
+-        if (!listTag.isEmpty() || setIfEmpty) {
++        if ((!listTag.isEmpty() || setIfEmpty) && !(total > NbtUtility.MAXIMUM_SIZE)) {
+             nbt.put("Items", listTag);
+         }
+ 
+@@ -42,11 +47,18 @@ public class ContainerHelper {
+ 
+     public static void loadAllItems(CompoundTag nbt, NonNullList<ItemStack> stacks) {
+         ListTag listTag = nbt.getList("Items", 10);
++        // Scissors - Account for items inside containers
++        long total = 0;
+ 
+         for(int i = 0; i < listTag.size(); ++i) {
+             CompoundTag compoundTag = listTag.getCompound(i);
+             int j = compoundTag.getByte("Slot") & 255;
+             if (j >= 0 && j < stacks.size()) {
++                total += NbtUtility.getTagSize(compoundTag);
++                if (total >= NbtUtility.MAXIMUM_SIZE) {
++                    stacks.clear();
++                    break;
++                }
+                 stacks.set(j, ItemStack.of(compoundTag));
+             }
+         }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
+index 1bb79768fe3be8a44a00e1f8686f95eed0dc2cf2..73e95e631ac622de897775399d205de66c4d8ff8 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world.level.block.entity;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Maps;
+ import it.unimi.dsi.fastutil.objects.Object2IntMap.Entry;
+@@ -209,6 +210,17 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+     public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
+ 
+     public List<ItemStack> getContents() {
++        // Scissors - Account for items inside containers
++        long total = 0;
++
++        for (ItemStack item : this.items) {
++            total += NbtUtility.getTagSize(item.getOrCreateTag());
++        }
++
++        if (total > NbtUtility.MAXIMUM_SIZE) {
++            this.items.clear();
++        }
++
+         return this.items;
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BarrelBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BarrelBlockEntity.java
+index f494063ead9c6303fb3ca880aba2a877ae8d83ab..7ec2f7f9ea8e75d5a04c700fce783a21a9b560f8 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BarrelBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BarrelBlockEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world.level.block.entity;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.Direction;
+ import net.minecraft.core.NonNullList;
+@@ -35,6 +36,17 @@ public class BarrelBlockEntity extends RandomizableContainerBlockEntity {
+ 
+     @Override
+     public List<ItemStack> getContents() {
++        // Scissors - Account for items inside containers
++        long total = 0;
++
++        for (ItemStack item : this.items) {
++            total += NbtUtility.getTagSize(item.getOrCreateTag());
++        }
++
++        if (total > NbtUtility.MAXIMUM_SIZE) {
++            this.items.clear();
++        }
++
+         return this.items;
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java
+index 3e71a16ae77601f589f4283a72ef8b68aae60db3..27fb605dbaefbb3a8eed25a519af4062e67aee26 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world.level.block.entity;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import java.util.Arrays;
+ import java.util.Iterator;
+ import javax.annotation.Nullable;
+@@ -72,6 +73,17 @@ public class BrewingStandBlockEntity extends BaseContainerBlockEntity implements
+     }
+ 
+     public List<ItemStack> getContents() {
++        // Scissors - Account for items inside containers
++        long total = 0;
++
++        for (ItemStack item : this.items) {
++            total += NbtUtility.getTagSize(item.getOrCreateTag());
++        }
++
++        if (total > NbtUtility.MAXIMUM_SIZE) {
++            this.items.clear();
++        }
++
+         return this.items;
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/ChestBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/ChestBlockEntity.java
+index 52de9852f87d346714a950b60a0004d386ac10f0..14854956a81c5f6da4d3f3ff2e910f37f32c21f7 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/ChestBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/ChestBlockEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world.level.block.entity;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.Direction;
+ import net.minecraft.core.NonNullList;
+@@ -41,6 +42,17 @@ public class ChestBlockEntity extends RandomizableContainerBlockEntity implement
+     private int maxStack = MAX_STACK;
+ 
+     public List<ItemStack> getContents() {
++        // Scissors - Account for items inside containers
++        long total = 0;
++
++        for (ItemStack item : this.items) {
++            total += NbtUtility.getTagSize(item.getOrCreateTag());
++        }
++
++        if (total > NbtUtility.MAXIMUM_SIZE) {
++            this.items.clear();
++        }
++
+         return this.items;
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/DispenserBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/DispenserBlockEntity.java
+index cfec89db4300bdb96a220540ee87892d22215e9d..ea14263bc11a80657b099342c1d6bb239ea1c80e 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/DispenserBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/DispenserBlockEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world.level.block.entity;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import java.util.Random;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.NonNullList;
+@@ -31,6 +32,17 @@ public class DispenserBlockEntity extends RandomizableContainerBlockEntity {
+     private int maxStack = MAX_STACK;
+ 
+     public List<ItemStack> getContents() {
++        // Scissors - Account for items inside containers
++        long total = 0;
++
++        for (ItemStack item : this.items) {
++            total += NbtUtility.getTagSize(item.getOrCreateTag());
++        }
++
++        if (total > NbtUtility.MAXIMUM_SIZE) {
++            this.items.clear();
++        }
++
+         return this.items;
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+index 06ffdf7301c8c9a02b4aa3693c69984064c8e085..ed28d8a30f9238a94ff6aff00740b77d12bfb8d6 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world.level.block.entity;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.function.BooleanSupplier;
+@@ -53,7 +54,19 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     private int maxStack = MAX_STACK;
+ 
+     public List<ItemStack> getContents() {
++        // Scissors - Account for items inside containers
++        long total = 0;
++
++        for (ItemStack item : this.items) {
++            total += NbtUtility.getTagSize(item.getOrCreateTag());
++        }
++
++        if (total > NbtUtility.MAXIMUM_SIZE) {
++            this.items.clear();
++        }
++
+         return this.items;
++
+     }
+ 
+     public void onOpen(CraftHumanEntity who) {
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
+index 01d77f800a1497418f08b8d52b0b7995bfbb5f4e..281d5f875de4bfaca1efc281e595cfa0dc492ede 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.world.level.block.entity;
+ 
++import com.github.atlasmediagroup.scissors.NbtUtility;
+ import java.util.List;
+ import java.util.stream.IntStream;
+ import javax.annotation.Nullable;
+@@ -257,7 +258,19 @@ public class ShulkerBoxBlockEntity extends RandomizableContainerBlockEntity impl
+ 
+     @Override
+     protected NonNullList<ItemStack> getItems() {
++        // Scissors - Account for items inside containers
++        long total = 0;
++
++        for (ItemStack item : this.itemStacks) {
++            total += NbtUtility.getTagSize(item.getOrCreateTag());
++        }
++
++        if (total > NbtUtility.MAXIMUM_SIZE) {
++            this.itemStacks.clear();
++        }
++
+         return this.itemStacks;
++
+     }
+ 
+     @Override


### PR DESCRIPTION
The combined size of items inside of containers weren't accounted for by the large item wiper. This patch fixes that.