### PR TITLE
Optimize getTagSize method in NbtUtility

### DIFF
--- a/patches/server/0031-Make-the-maximum-tag-size-a-constant-add-a-method-fo.patch
+++ b/patches/server/0031-Make-the-maximum-tag-size-a-constant-add-a-method-fo.patch
@@ -6,18 +6,51 @@ Subject: [PATCH] Make the maximum tag size a constant & add a method for
 
 
 diff --git a/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java b/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java
-index 058203440fd071ce5edbe18391ea60f0a5fbee3a..dc09fe007247e832aacc323ddeb3541cfb447069 100644
+index 058203440fd071ce5edbe18391ea60f0a5fbee3a..978cb98c81195640fb3704d2077148f2be0dca36 100644
 --- a/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java
 +++ b/src/main/java/com/github/atlasmediagroup/scissors/NbtUtility.java
-@@ -7,11 +7,17 @@ import java.nio.charset.StandardCharsets;
+@@ -1,17 +1,49 @@
+ package com.github.atlasmediagroup.scissors;
+ 
+-import net.minecraft.nbt.CompoundTag;
++import com.google.common.base.Strings;
++import com.google.common.collect.Lists;
++import net.minecraft.nbt.*;
+ 
+ import javax.annotation.Nullable;
+ import java.nio.charset.StandardCharsets;
++import java.util.Collections;
++import java.util.List;
  
  public class NbtUtility
  {
 +    public static final long MAXIMUM_SIZE = (256 * 1024);
 +
-+    public static long getTagSize(@Nullable CompoundTag tag) {
++    public static long getTagSize(@Nullable Tag tag, int depth) {
++        if(depth > 512) return 0;
 +        if(tag == null) return 0;
-+        return tag.toString().getBytes(StandardCharsets.UTF_8).length;
++
++        long size = 0;
++
++        if(tag.getType() == CompoundTag.TYPE) {
++            CompoundTag compoundTag = (CompoundTag) tag;
++            for(String key : compoundTag.getAllKeys()) {
++                size += getTagSize(compoundTag.get(key), depth + 1);
++            }
++        } else if(tag.getType() == ListTag.TYPE) {
++            ListTag listTag = (ListTag) tag;
++            for (Tag tag1 : listTag) {
++                size += getTagSize(tag1, depth + 1);
++            }
++        } else {
++            size += tag.getAsString().getBytes(StandardCharsets.UTF_8).length;
++        }
++
++        return size;
++    }
++
++    public static long getTagSize(@Nullable CompoundTag tag) {
++        return getTagSize(tag, 0);
 +    }
  
      public static boolean isTooLarge(@Nullable CompoundTag tag)


### PR DESCRIPTION
This fixes that lag exploit with armor stands in containers caused by Scissors.