### PR TITLE
Make excluding players from `nbt` components configurable

### DIFF
--- a/patches/server/0046-Make-excluding-players-from-nbt-components-configura.patch
+++ b/patches/server/0046-Make-excluding-players-from-nbt-components-configura.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chipmunk <65827213+ChipmunkMC@users.noreply.github.com>
+Date: Mon, 1 May 2023 09:13:50 -0400
+Subject: [PATCH] Make excluding players from nbt components configurable
+
+
+diff --git a/src/main/java/me/totalfreedom/scissors/ScissorsConfig.java b/src/main/java/me/totalfreedom/scissors/ScissorsConfig.java
+index 9f2a51fddb692f5152c32dcbe1f5a6ba150634e4..39b56ca496ed7369ead21805d476c2b813fcdd1d 100644
+--- a/src/main/java/me/totalfreedom/scissors/ScissorsConfig.java
++++ b/src/main/java/me/totalfreedom/scissors/ScissorsConfig.java
+@@ -87,8 +87,8 @@ public class ScissorsConfig
+         config.options().header(HEADER);
+         config.options().copyDefaults(true);
+ 
+-        version = getInt("config-version", 3);
+-        set("config-version", 3);
++        version = getInt("config-version", 4);
++        set("config-version", 4);
+         readConfig(ScissorsConfig.class, null);
+     }
+ 
+@@ -169,6 +169,12 @@ public class ScissorsConfig
+         chatSignaturesEnabled = getBoolean("chatSignaturesEnabled", true);
+     }
+ 
++    public static boolean excludePlayersFromNbtComponents = false;
++    private static void excludePlayersFromNbtComponents()
++    {
++        excludePlayersFromNbtComponents = getBoolean("excludePlayersFromNbtComponents", false);
++    }
++
+     private static void set(String path, Object val)
+     {
+         config.set(path, val);
+diff --git a/src/main/java/net/minecraft/network/chat/contents/EntityDataSource.java b/src/main/java/net/minecraft/network/chat/contents/EntityDataSource.java
+index e5a2bb129100f0f935c8f10682204e7cb6277142..1ebc6107bbbf18dd9ede1196769e43ee7cb9d448 100644
+--- a/src/main/java/net/minecraft/network/chat/contents/EntityDataSource.java
++++ b/src/main/java/net/minecraft/network/chat/contents/EntityDataSource.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.network.chat.contents;
+ 
++import me.totalfreedom.scissors.ScissorsConfig;
+ import com.mojang.brigadier.StringReader;
+ import com.mojang.brigadier.exceptions.CommandSyntaxException;
+ import java.util.List;
+@@ -32,7 +33,11 @@ public record EntityDataSource(String selectorPattern, @Nullable EntitySelector
+     public Stream<CompoundTag> getData(CommandSourceStack source) throws CommandSyntaxException {
+         if (this.compiledSelector != null) {
+             List<? extends Entity> list = this.compiledSelector.findEntities(source);
+-            return list.stream().filter((entity) -> !(entity instanceof Player)).map(NbtPredicate::getEntityTagToCompare); // Scissors - Don't query NBT from players
++	    // Scissors start
++            Stream<? extends Entity> stream = list.stream();
++            if (ScissorsConfig.excludePlayersFromNbtComponents) stream = stream.filter((entity) -> !(entity instanceof Player));
++            return stream.map(NbtPredicate::getEntityTagToCompare);
++	    // Scissors end
+         } else {
+             return Stream.empty();
+         }


### PR DESCRIPTION
This makes it possible for server owners to not have the server exclude players in `nbt` components. Note that the configuration option is `false` by default, meaning players will be included in `nbt` components by default. (I can change that if you want)